### PR TITLE
Updated encoding, error introduction and frame conversion

### DIFF
--- a/src/prep/include/encoding.hpp
+++ b/src/prep/include/encoding.hpp
@@ -10,9 +10,10 @@
 #include "encodingtables.hpp"
 #include "constants.hpp"
 
-using byte = std::uint8_t;
-using bytesVec = std::vector<byte>;
-using symbol10 = std::uint16_t;
+using byte = std::uint8_t;                  // 8-bit byte
+using bytesVec = std::vector<byte>;         // vector of bytes
+using symbol10 = std::uint16_t;             // 10-bit symbol - stored on younger 10 bits of uint16_t
+using symbolVec = std::vector<symbol10>;    // vector of 10-bit symbols
 
 namespace encodings {
     /**
@@ -99,6 +100,14 @@ namespace encodings {
     bytesVec encodeBytesVec8b10b(const bytesVec& data);
 
     /**
+     * @brief Encodes vector of bytes using the 8b/10b encoding
+     * 
+     * @param data       vector of bytes to encode
+     * @return symbolVec result vector of 10-bit symbols  from the encoding
+     */
+    symbolVec encode8b10b(const bytesVec& data);
+
+    /**
      * @brief Decodes 10bit symbol to 8bit symbol
      * @details Decodes 10bit symbol to 8bit symbol, using 5b/6b and 3b/4b decodings
      *          See https://en.wikipedia.org/wiki/8b/10b_encoding for more detailed explanation of the algorithm
@@ -127,4 +136,12 @@ namespace encodings {
      * @return bytesVec decoded vector of bytes
      */
     bytesVec decodeBytesVec10b8b(const bytesVec& data);
+
+    /**
+     * @brief Decode vector of 10-bit symbols to vector of bytes, using the 8b/10b encoding
+     * 
+     * @param data      vector of 10-bit symbols endoded in 8b/10b 
+     * @return bytesVec decoded vector of bytes
+     */
+    bytesVec decode8b10b(const symbolVec& data);
 };

--- a/src/prep/include/transerrors.hpp
+++ b/src/prep/include/transerrors.hpp
@@ -15,6 +15,7 @@
 using byte = std::uint8_t;
 using bytesVec = std::vector<byte>;
 using symbol10 = std::uint16_t;
+using symbolVec = std::vector<symbol10>;
 
 const std::unordered_map<std::string, int> FIELDS_TEMPLATE_MAP = {
     {"DestMAC", 0},
@@ -38,9 +39,18 @@ namespace transerrors {
     * 
     * @param data      vector of original bytes, not modified
     * @param positions vector of positions to negate bits at, should be no longer than 8*data.size() (nr of bits in data)
-    * @return          vector of bytes with bits negated at given positions
+    * @return bytesVec vector of bytes with bits negated at given positions
     */
     bytesVec flipBits(const bytesVec&data, const std::unordered_set<int>& positions);
+
+    /**
+     * @brief Negates bits at given positions in given vector of 10-bit symbols
+     * 
+     * @param data       vector of original 10-bit symbols, not modified
+     * @param positions  vector of positions to negate bits at, should be no longer than 10*data.size() (nr of bits in data)
+     * @return symbolVec vector of 10-bit symbols with bits negated at given positions
+     */
+    symbolVec flipBits(const symbolVec&data, const std::unordered_set<int>& positions);
 
     /**
      * @brief Get the position of random bit in destination MAC field of 8b/10b encoded Ethernet II frame

--- a/src/prep/src/transerrors.cpp
+++ b/src/prep/src/transerrors.cpp
@@ -6,7 +6,19 @@ namespace transerrors {
         bytesVec flipped = data;
         for (int pos : positions) {
             try {
-                flipped.at(pos / 8) ^= (1 << (pos % 8));
+                flipped.at((int) (pos / 8)) ^= (1 << std::abs((pos % 8) - 8));
+            } catch (std::out_of_range& e) {
+                //std::cout << "Out of range: " << pos << std::endl;
+            }
+        }
+        return flipped;
+    }
+
+    symbolVec flipBits(const symbolVec&data, const std::unordered_set<int>& positions) {
+        symbolVec flipped = data;
+        for (int pos : positions) {
+            try {
+                flipped.at((int) (pos / 10)) ^= (1 << std::abs((pos % 10) - 9));
             } catch (std::out_of_range& e) {
                 //std::cout << "Out of range: " << pos << std::endl;
             }


### PR DESCRIPTION
Now the frame (with checksum, but no padding) is encoded, than errors are introduced and the frame (& checksum) are decoded back into bytes. Finally checksum is separated, padding added and checksum reattached at the end of the frame. 