### PR TITLE
Remove raw capture file from repo

### DIFF
--- a/data/raw/capture1.txt
+++ b/data/raw/capture1.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6c4e5225d0fa6bc4042e9434f819a435fc178c31fdc2ac2dbb4abd619f2dad6d
-size 581404484


### PR DESCRIPTION
The raw capture file from Wireshark shall be removed from git repo and moved to dedicated outside hosting